### PR TITLE
Added PKCE support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/tmp
 tmp
 .idea
 bin
+*.env.json

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ docker build . -t sdo_omniauth_ping_one
 docker run --rm sdo_omniauth_ping_one 
 ```
 
-
 ### OAuth scopes
 
 [PingOne supports different OAuth scopes][oauth-scopes]. 
@@ -51,6 +50,7 @@ Under `config/initializers/omniauth.rb`:
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
     provider :ping_one, ENV['OAUTH_PING_ONE_CLIENT_ID'], ENV['OAUTH_PING_ONE_CLIENT_SECRET'], {
+        :pkce => false,
         :client_options => {
             site: ENV['OAUTH_PING_ONE_SITE'],
             redirect_uri: ENV['OAUTH_PING_ONE_REDIRECT_URI'],

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ docker build . -t sdo_omniauth_ping_one
 docker run --rm sdo_omniauth_ping_one 
 ```
 
+### Run tests in container
+
+```bash 
+export IMAGE=omniauth-ping-one:localdev
+docker build --tag $IMAGE .
+docker run \
+    -v $PWD/spec:/usr/src/app/spec \
+    -v $PWD/lib:/usr/src/app/lib \
+    $IMAGE
+```
+
 ### OAuth scopes
 
 [PingOne supports different OAuth scopes][oauth-scopes]. 

--- a/lib/omniauth/strategies/ping-one.rb
+++ b/lib/omniauth/strategies/ping-one.rb
@@ -15,6 +15,12 @@ module OmniAuth
                 %w[openid profile email]
             end
 
+            # Ping rejects auth token requests with client secret when the client is in gung-ho PKCE mode, so we do not set it.
+            def auth_token_client
+                return client unless options.pkce
+                ::OAuth2::Client.new(options.client_id, nil, deep_symbolize(options.client_options))
+            end
+
             def authorize_params
                 super.tap do |params|
                     params[:scope] = options[:scopes].join(' ')
@@ -46,7 +52,11 @@ module OmniAuth
             # may otherwise reject the request.
             def build_access_token
                 verifier = request.params["code"]
-                client.auth_code.get_token(verifier, token_params.to_hash(:symbolize_keys => true), { :redirect_uri => callback_url }.merge(deep_symbolize(options.auth_token_params)))
+                auth_token_client.auth_code.get_token(
+                    verifier,
+                    token_params.to_hash(:symbolize_keys => true),
+                    { :redirect_uri => callback_url }.merge(deep_symbolize(options.auth_token_params))
+                )
             end
         end
     end

--- a/lib/omniauth/strategies/ping-one.rb
+++ b/lib/omniauth/strategies/ping-one.rb
@@ -15,8 +15,8 @@ module OmniAuth
                 %w[openid profile email]
             end
 
-            # Ping rejects auth token requests with client secret when the client is in gung-ho PKCE mode, so we do not set it.
-            def auth_token_client
+            # Ping rejects access token requests with client secret when the client is in gung-ho PKCE mode, so we do not set it.
+            def access_token_client
                 return client unless options.pkce
                 ::OAuth2::Client.new(options.client_id, nil, deep_symbolize(options.client_options))
             end
@@ -52,7 +52,7 @@ module OmniAuth
             # may otherwise reject the request.
             def build_access_token
                 verifier = request.params["code"]
-                auth_token_client.auth_code.get_token(
+                access_token_client.auth_code.get_token(
                     verifier,
                     token_params.to_hash(:symbolize_keys => true),
                     { :redirect_uri => callback_url }.merge(deep_symbolize(options.auth_token_params))

--- a/spec/omniauth/strategies/ping_one_pkce_spec.rb
+++ b/spec/omniauth/strategies/ping_one_pkce_spec.rb
@@ -22,7 +22,7 @@ describe OmniAuth::Strategies::PingOne do
     context 'configured service with given params' do
         it "given params" do
             expect(subject.client.secret).to eq "Z" # Default client always has a secret
-            expect(subject.auth_token_client.secret).to eq nil # Auth token client never has a secret in PKCE mode
+            expect(subject.access_token_client.secret).to eq nil # Access token client never has a secret in PKCE mode
             expect(subject.options.client_options.site).to eq "https://site.example.com"
             expect(subject.options.client_options.redirect_uri).to eq "https://you.example.com/auth/ping_one/callback"
             expect(subject.options.client_options.authorize_url).to eq '/xxx/as/authorization.oauth2'

--- a/spec/omniauth/strategies/ping_one_pkce_spec.rb
+++ b/spec/omniauth/strategies/ping_one_pkce_spec.rb
@@ -1,6 +1,6 @@
 require 'omniauth/strategies/ping-one'
 describe OmniAuth::Strategies::PingOne do
-    let(:ping_one_service) { OmniAuth::Strategies::PingOne.new("X", "Y", "Z", { :pkce => false, :client_options => {
+    let(:ping_one_service) { OmniAuth::Strategies::PingOne.new("X", "Y", "Z", { :pkce => true, :client_options => {
         site: "https://site.example.com",
         redirect_uri: "https://you.example.com/auth/ping_one/callback",
         authorize_url: '/xxx/as/authorization.oauth2',
@@ -12,7 +12,7 @@ describe OmniAuth::Strategies::PingOne do
     context 'configured service with given params' do
         it "given params" do
             expect(subject.client.secret).to eq "Z" # Default client always has a secret
-            expect(subject.auth_token_client.secret).to eq "Z" # Auth token client always has a secret in non-PKCE mode
+            expect(subject.auth_token_client.secret).to eq nil # Auth token client never has a secret in PKCE mode
             expect(subject.options.client_options.site).to eq "https://site.example.com"
             expect(subject.options.client_options.redirect_uri).to eq "https://you.example.com/auth/ping_one/callback"
             expect(subject.options.client_options.authorize_url).to eq '/xxx/as/authorization.oauth2'

--- a/spec/omniauth/strategies/ping_one_pkce_spec.rb
+++ b/spec/omniauth/strategies/ping_one_pkce_spec.rb
@@ -1,12 +1,22 @@
 require 'omniauth/strategies/ping-one'
 describe OmniAuth::Strategies::PingOne do
-    let(:ping_one_service) { OmniAuth::Strategies::PingOne.new("X", "Y", "Z", { :pkce => true, :client_options => {
-        site: "https://site.example.com",
-        redirect_uri: "https://you.example.com/auth/ping_one/callback",
-        authorize_url: '/xxx/as/authorization.oauth2',
-        token_url: '/xxx/as/token.oauth2',
-        user_url: '/xxx/idp/userinfo.openid',
-    }, :scopes => %w[profile email openid] }) }
+    let(:ping_one_service) {
+        OmniAuth::Strategies::PingOne.new(
+            "X",
+            "Y",
+            "Z",
+            {
+                :pkce => true,
+                :client_options => { site: "https://site.example.com",
+                                     redirect_uri: "https://you.example.com/auth/ping_one/callback",
+                                     authorize_url: '/xxx/as/authorization.oauth2',
+                                     token_url: '/xxx/as/token.oauth2',
+                                     user_url: '/xxx/idp/userinfo.openid',
+                },
+                :scopes => %w[profile email openid]
+            }
+        )
+    }
     subject { ping_one_service }
 
     context 'configured service with given params' do

--- a/spec/omniauth/strategies/ping_one_spec.rb
+++ b/spec/omniauth/strategies/ping_one_spec.rb
@@ -1,12 +1,21 @@
 require 'omniauth/strategies/ping-one'
 describe OmniAuth::Strategies::PingOne do
-    let(:ping_one_service) { OmniAuth::Strategies::PingOne.new("X", "Y", "Z", { :pkce => false, :client_options => {
-        site: "https://site.example.com",
-        redirect_uri: "https://you.example.com/auth/ping_one/callback",
-        authorize_url: '/xxx/as/authorization.oauth2',
-        token_url: '/xxx/as/token.oauth2',
-        user_url: '/xxx/idp/userinfo.openid',
-    }, :scopes => %w[profile email openid] }) }
+    let(:ping_one_service) {
+        OmniAuth::Strategies::PingOne.new(
+            "X",
+            "Y",
+            "Z",
+            {
+                :client_options => { site: "https://site.example.com",
+                                     redirect_uri: "https://you.example.com/auth/ping_one/callback",
+                                     authorize_url: '/xxx/as/authorization.oauth2',
+                                     token_url: '/xxx/as/token.oauth2',
+                                     user_url: '/xxx/idp/userinfo.openid',
+                },
+                :scopes => %w[profile email openid]
+            }
+        )
+    }
     subject { ping_one_service }
 
     context 'configured service with given params' do

--- a/spec/omniauth/strategies/ping_one_spec.rb
+++ b/spec/omniauth/strategies/ping_one_spec.rb
@@ -21,7 +21,7 @@ describe OmniAuth::Strategies::PingOne do
     context 'configured service with given params' do
         it "given params" do
             expect(subject.client.secret).to eq "Z" # Default client always has a secret
-            expect(subject.auth_token_client.secret).to eq "Z" # Auth token client always has a secret in non-PKCE mode
+            expect(subject.access_token_client.secret).to eq "Z" # Access token client always has a secret in non-PKCE mode
             expect(subject.options.client_options.site).to eq "https://site.example.com"
             expect(subject.options.client_options.redirect_uri).to eq "https://you.example.com/auth/ping_one/callback"
             expect(subject.options.client_options.authorize_url).to eq '/xxx/as/authorization.oauth2'


### PR DESCRIPTION
Ping rejects access token requests when the client secret is given, additionally to the code_challenge. At least in the current case I am facing now.

The temp solution right now is to have a dedicated HTTP client that does not set the OIDC secret for the access token request.